### PR TITLE
Update README.md

### DIFF
--- a/BeefProj.toml
+++ b/BeefProj.toml
@@ -6,19 +6,19 @@ TargetType = "BeefLib"
 
 [Configs.Debug.Win64]
 LibPaths = ["$(ProjectDir)\\.build\\win64_vs2019\\bin\\nativefiledialogDebug.lib"]
-OtherLinkFlags = "$(LinkFlags) comctl32.lib"
+OtherLinkFlags = "$(LinkFlags) comctl32.lib Ole32.lib Shell32.lib"
 
 [Configs.Release.Win64]
 LibPaths = ["$(ProjectDir)\\.build\\win64_vs2019\\bin\\nativefiledialogRelease.lib"]
-OtherLinkFlags = "$(LinkFlags) comctl32.lib"
+OtherLinkFlags = "$(LinkFlags) comctl32.lib Ole32.lib Shell32.lib"
 
 [Configs.Paranoid.Win64]
 LibPaths = ["$(ProjectDir)\\.build\\win64_vs2019\\bin\\nativefiledialogRelease.lib"]
-OtherLinkFlags = "$(LinkFlags) comctl32.lib"
+OtherLinkFlags = "$(LinkFlags) comctl32.lib Ole32.lib Shell32.lib"
 
 [Configs.Test.Win64]
 LibPaths = ["$(ProjectDir)\\.build\\win64_vs2019\\bin\\nativefiledialogRelease.lib"]
-OtherLinkFlags = "$(LinkFlags) comctl32.lib"
+OtherLinkFlags = "$(LinkFlags) comctl32.lib Ole32.lib Shell32.lib"
 
 [Configs.Debug.macOS]
 LibPaths = ["$(ProjectDir)\\.build\\osx-x64\\bin\\libnativefiledialogDebug.a"]

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 ## Windows
 - Visual Studio 2019 Community/Professional (it can be built with other versions though, check build_windows_vs2019.cmd for more information)
 - To build prerequisites run *build_windows_vs2019.cmd*
-- You may have to add `Ole32.lib` and `Shell32.lib` to the `Additional Lib Paths` field in the Build tab of your project properties.
 
 ## MacOS
 - To build prerequisites run *./build_macos.sh*

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ## Windows
 - Visual Studio 2019 Community/Professional (it can be built with other versions though, check build_windows_vs2019.cmd for more information)
 - To build prerequisites run *build_windows_vs2019.cmd*
+- You may have to add `Ole32.lib` and `Shell32.lib` to the `Additional Lib Paths` field in the Build tab of your project properties.
 
 ## MacOS
 - To build prerequisites run *./build_macos.sh*


### PR DESCRIPTION
I had to add Ole32.lib and Shell32.lib to "Additional Lib Paths" in my beef project to fix linker errors. Figure that should be in the readme in case anyone else hits the same problem.